### PR TITLE
Remove dependence on SwiftCrypto so we can deploy to iOS 12.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "swift-srp",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v13),
+        .iOS(.v12),
         .watchOS(.v6),
         .tvOS(.v13),
     ],
@@ -15,11 +15,10 @@ let package = Package(
         .library(name: "SRP", targets: ["SRP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto", from: "1.0.0"),
         .package(url: "https://github.com/adam-fowler/big-num", from: "2.0.0"),
     ],
     targets: [
-        .target(name: "SRP", dependencies: ["BigNum", "Crypto"]),
+        .target(name: "SRP", dependencies: ["BigNum"]),
         .testTarget(
             name: "SRPTests", dependencies: ["SRP"]),
     ]

--- a/Sources/SRP/client.swift
+++ b/Sources/SRP/client.swift
@@ -1,5 +1,4 @@
 import BigNum
-import Crypto
 
 /// Manages the client side of Secure Remote Password
 ///
@@ -42,7 +41,7 @@ public struct SRPClient<H: HashFunction> {
         var a = BigNum()
         var A = BigNum()
         repeat {
-            a = BigNum(bytes: SymmetricKey(size: .bits256))
+            a = BigNum(bytes: SymmetricKey(size: 32))
             A = configuration.g.power(a, modulus: configuration.N)
         } while A % configuration.N == BigNum(0)
 

--- a/Sources/SRP/configuration.swift
+++ b/Sources/SRP/configuration.swift
@@ -1,5 +1,4 @@
 import BigNum
-import Crypto
 
 /// SRP Configuration. The same configuration hast to be used by both client and server. Contains a large safe prime N ie a prime where the value (N-1)/2 is also a prime, g the multiplicative group generator and the value k = Hash(N | g)
 public struct SRPConfiguration<H: HashFunction> {

--- a/Sources/SRP/crypto.swift
+++ b/Sources/SRP/crypto.swift
@@ -1,0 +1,74 @@
+//
+//  File.swift
+//  
+//
+//  Created by Joseph Ross on 4/26/21.
+//
+
+import Foundation
+import CommonCrypto
+
+public protocol HashFunction {
+    static func hash<D>(data: D) -> Data where D : DataProtocol
+}
+
+public enum Insecure {
+}
+
+extension Insecure {
+
+    /// The SHA-1 Hash Function.
+    /// ⚠️ Security Recommendation: The SHA-1 hash function is no longer considered secure. We strongly recommend using the SHA-256 hash function instead.
+    public struct SHA1 {
+        @inlinable public static func hash<D>(data: D) -> Data where D : DataProtocol {
+            var digest = Data(count:20)
+            let data = Data(data)
+        
+            let _ = data.withUnsafeBytes() { dataPtr in
+                digest.withUnsafeMutableBytes() { digestPtr in
+                    CC_SHA1(dataPtr, UInt32(data.count), digestPtr)
+                }
+            }
+            return digest
+        }
+    }
+}
+
+public struct SHA256 {
+    @inlinable public static func hash<D>(data: D) -> Data where D : DataProtocol {
+        var digest = Data(count:32)
+        let data = Data(data)
+    
+        let _ = data.withUnsafeBytes() { dataPtr in
+            digest.withUnsafeMutableBytes() { digestPtr in
+                CC_SHA256(dataPtr, UInt32(data.count), digestPtr)
+            }
+        }
+        return digest
+    }
+}
+
+extension Insecure.SHA1 : HashFunction {
+}
+
+extension SHA256: HashFunction {
+}
+
+public struct SymmetricKey {
+    let data: Data
+    init(size: Int) {
+        var data = Data(count:size)
+        data.withUnsafeMutableBytes { dataPtr in
+            CCRandomGenerateBytes(dataPtr, size)
+        }
+        self.data = data
+    }
+}
+
+extension SymmetricKey: ContiguousBytes {
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        try data.withUnsafeBytes { buffer in
+            try body(buffer)
+        }
+    }
+}

--- a/Sources/SRP/server.swift
+++ b/Sources/SRP/server.swift
@@ -1,5 +1,4 @@
 import BigNum
-import Crypto
 
 /// Manages the server side of Secure Remote Password.
 ///
@@ -46,7 +45,7 @@ public struct SRPServer<H: HashFunction> {
         var b: BigNum
         var B: BigNum
         repeat {
-            b = BigNum(bytes: SymmetricKey(size: .bits256))
+            b = BigNum(bytes: SymmetricKey(size: 32))
             B = (configuration.k * verifier.number + configuration.g.power(b, modulus: configuration.N)) % configuration.N
         } while B % configuration.N == BigNum(0)
         

--- a/Sources/SRP/srp.swift
+++ b/Sources/SRP/srp.swift
@@ -1,5 +1,4 @@
 import BigNum
-import Crypto
 
 /// Contains common code used by both client and server SRP code
 public struct SRP<H: HashFunction> {

--- a/Tests/SRPTests/SRPTests.swift
+++ b/Tests/SRPTests/SRPTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import BigNum
-import Crypto
 @testable import SRP
 
 final class SRPTests: XCTestCase {
@@ -73,10 +72,6 @@ final class SRPTests: XCTestCase {
         testVerifySRP(configuration: SRPConfiguration<Insecure.SHA1>(.N4096))
         testVerifySRP(configuration: SRPConfiguration<Insecure.SHA1>(.N6144))
         testVerifySRP(configuration: SRPConfiguration<Insecure.SHA1>(.N8192))
-    }
-
-    func testVerifySRPCustomConfiguration() {
-        testVerifySRP(configuration: SRPConfiguration<SHA384>(N: BigNum(37), g: BigNum(3)))
     }
 
     func testClientSessionProof() {
@@ -175,7 +170,6 @@ final class SRPTests: XCTestCase {
     static var allTests = [
         ("testSRPSharedSecret", testSRPSharedSecret),
         ("testVerifySRP", testVerifySRP),
-        ("testVerifySRPCustomConfiguration", testVerifySRPCustomConfiguration),
         ("testClientSessionProof", testClientSessionProof),
         ("testServerSessionProof", testServerSessionProof),
         ("testRFC5054Appendix", testRFC5054Appendix),


### PR DESCRIPTION
This library is very nicely put together and I found it to be a great replacement for the messy SRP implementation we already had in place which depended on OpenSSL prebuilts.  But I didn't love the iOS 13 deployment target.  So I tried eliminating the SwiftCrypto dependency, just relying on CommonCrypto which is available in older versions of iOS.  The swap turned out to be surprisingly easy, though not as full-featured.  

I realized this might feel like a step backward and may be rejected.  That's ok with me.  I just want to put the thought out there for backwards-compatibility's sake.  I'm sure in a year we'll drop our need for the iOS 12.1 deployment target and I'll be happy to depend on SwiftCrypto.