### PR TITLE
Add public initializer to SRPKeyPair

### DIFF
--- a/Sources/SRP/keys.swift
+++ b/Sources/SRP/keys.swift
@@ -26,5 +26,10 @@ extension SRPKey: Equatable { }
 public struct SRPKeyPair {
     public let `public`: SRPKey
     public let `private`: SRPKey
+
+    public init(`public`: SRPKey, `private`: SRPKey) {
+        self.private = `private`
+        self.public = `public`
+    }
 }
 

--- a/Sources/SRP/keys.swift
+++ b/Sources/SRP/keys.swift
@@ -22,11 +22,16 @@ public struct SRPKey {
 
 extension SRPKey: Equatable { }
 
-/// contains a private and a public key
+/// Contains a private and a public key
 public struct SRPKeyPair {
     public let `public`: SRPKey
     public let `private`: SRPKey
 
+
+    /// Initialise a SRPKeyPair object
+    /// - Parameters:
+    ///   - public: The public key of the key pair
+    ///   - private: The private key of the key pair
     public init(`public`: SRPKey, `private`: SRPKey) {
         self.private = `private`
         self.public = `public`


### PR DESCRIPTION
Until now the `SRPKeyPair` initializer was private which is very unlucky if you want to manually test `SRPClient.calculateSharedSecret` using hardcoded credentials, salts and keys etc. ...

Another solution would be to split up the `clientKeys` parameter in (`SRPClient.calculateSharedSecret`), but... I think it's fine just being able to create a `SRPKeyPair` by hand.

PS: This is my very first OpenSource contribution ever 🎉