### PR TITLE
Fix calculation of client proof

### DIFF
--- a/Sources/SRP/client.swift
+++ b/Sources/SRP/client.swift
@@ -1,5 +1,6 @@
 import BigNum
 import Crypto
+import Foundation
 
 /// Manages the client side of Secure Remote Password
 ///
@@ -51,8 +52,21 @@ public struct SRPClient<H: HashFunction> {
         let sharedSecret = try calculateSharedSecret(message: message, salt: salt, clientKeys: clientKeys, serverPublicKey: serverPublicKey)
         return SRPKey(sharedSecret)
     }
-    
-    
+
+    /// return shared secret given the password as Data, B value and salt from the server
+    /// - Parameters:
+    ///   - password: password
+    ///   - salt: salt
+    ///   - clientKeys: client public/private keys
+    ///   - serverPublicKey: server public key
+    /// - Throws: `nullServerKey`
+    /// - Returns: shared secret
+    public func calculateSharedSecret(password: Data, salt: [UInt8], clientKeys: SRPKeyPair, serverPublicKey: SRPKey) throws -> SRPKey {
+            let message = [UInt8](Data([0x3a]) + password)
+            let sharedSecret = try calculateSharedSecret(message: message, salt: salt, clientKeys: clientKeys, serverPublicKey: serverPublicKey)
+            return SRPKey(sharedSecret)
+    }
+
     /// calculate proof of shared secret to send to server
     /// - Parameters:
     ///   - clientPublicKey: client public key

--- a/Sources/SRP/srp.swift
+++ b/Sources/SRP/srp.swift
@@ -48,7 +48,7 @@ public struct SRP<H: HashFunction> {
         hashSharedSecret: [UInt8]) -> [UInt8]
     {
         // M = H(H(N)^ H(g)) | H(username) | salt | client key | server key | H(shared secret))
-        let N_xor_g = [UInt8](H.hash(data: configuration.N.bytes)) ^ [UInt8](H.hash(data: configuration.g.bytes))
+        let N_xor_g = [UInt8](H.hash(data: configuration.N.bytes)) ^ [UInt8](H.hash(data: pad(configuration.g.bytes, to: configuration.N.bytes.count)))
         let hashUser = H.hash(data: [UInt8](username.utf8))
         let M1 = [UInt8](N_xor_g) + hashUser + salt
         let M2 = clientPublicKey.bytes + serverPublicKey.bytes + hashSharedSecret


### PR DESCRIPTION
- Pad g with 0s to be of size N
- Add variant for generating client secret that accepts password as data and without username